### PR TITLE
German Translation

### DIFF
--- a/src/main/resources/assets/soulshardstow/lang/de_DE.lang
+++ b/src/main/resources/assets/soulshardstow/lang/de_DE.lang
@@ -1,0 +1,39 @@
+# Creative Tab
+itemGroup.soulShards=Soul Shards: Die alten Sitten
+
+# Items
+item.SoulShardsTOW.shard.name=Seelen Scherbe
+item.SoulShardsTOW.shard.unbound.name=Ungebundene Seelen Scherbe
+item.SoulShardsTOW.material.ingotCorrupted.name=Verdorbener Barren
+item.SoulShardsTOW.material.dustCorrupted.name=Verdorbene Essenz
+item.SoulShardsTOW.material.dustVile.name=Abscheulicher Staub
+item.SoulShardsTOW.soulSword.name=Abscheuliches Schwert
+
+# Blocks
+tile.SoulShardsTOW.cage.name=Seelen Käfig
+
+# Tooltips
+tooltip.SoulShardsTOW.bound=Gebunden an: %s
+tooltip.SoulShardsTOW.kills=Tötungen: %d
+tooltip.SoulShardsTOW.tier=Stufe: %d
+
+# Enchantment
+enchantment.soulStealer=Seelen Dieb
+
+# Entities
+entity.Wither Skeleton.name=Witherskelett
+
+# Chat
+chat.sstow.command.killed=&2Tötete %d Wesen
+chat.sstow.command.notfound=&cFand keine erzeugten Wesen
+chat.sstow.command.setwrong=&cUnzulässiges Argument
+chat.sstow.command.wrongcommand=&cUnzulässiger Befehl
+
+# Waila
+waila.SoulShardsTOW.sneak=&oSchleichen für Details
+waila.SoulShardsTOW.boundTo=Gebunden an: %s
+waila.SoulShardsTOW.tier=Stufe: %d
+waila.SoulShardsTOW.owner=Eigentümer: %s
+
+# JEI
+jei.SoulShards.soulshard.desc=Ein Gefäß für die Seelen der Gefallenen.\n\nErhalten durch Erstellung einer Struktur in der Welt und Anwendung eines Diamanten auf den Anfangsblock.


### PR DESCRIPTION
Corrupted is translated into decomposed etc meaning see http://bit.ly/1QEhblY
Vile is translated into abhorrent etc meaning see http://bit.ly/1QEhld3
Dust from Vile Dust is translated to poweder etc meaning see http://bit.ly/1QEhld3 http://bit.ly/1QEhywR

Concerning Chat... is the combined into "Player Fand keine erzeugten Wesen" if yes I need to change that. Also in that chat line... spawned entities... 
spawned is translated to generated , see http://bit.ly/1QEhL36
entities is translated to creature , see http://bit.ly/1QEhTzL
Are those translations fitting? Do they transfer the right meaning?
Haven't played ShouldShards yet.
