### PR TITLE
Prevent IllegalArgumentException in Soul Cages

### DIFF
--- a/src/main/java/com/whammich/sstow/tile/TileEntityCage.java
+++ b/src/main/java/com/whammich/sstow/tile/TileEntityCage.java
@@ -12,8 +12,10 @@ import com.whammich.sstow.item.ItemSoulShard;
 import com.whammich.sstow.util.EntityMapper;
 import com.whammich.sstow.util.TierHandler;
 import com.whammich.sstow.util.Utils;
+
 import lombok.Getter;
 import lombok.Setter;
+import net.minecraft.block.Block;
 import net.minecraft.entity.EntityList;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.monster.EntityMob;
@@ -148,6 +150,9 @@ public class TileEntityCage extends TileInventory implements ITickable, ISoulCag
     }
 
     public boolean getActiveState() {
+        Block b = getWorld().getBlockState(getPos()).getBlock();
+        if(!b.getBlockState().getProperties().contains(SoulShardsAPI.ACTIVE))
+            return false;
         return getWorld().getBlockState(getPos()).getValue(SoulShardsAPI.ACTIVE);
     }
 


### PR DESCRIPTION
Prevents [this crash](https://gist.github.com/Kraise/5eda6180861c10eb52548fbf2ea1f02c).

This seemed to randomly start happening on an Abridged server running forge and sponge. The BlockStateContainer block type on [line 23](https://gist.github.com/Kraise/5eda6180861c10eb52548fbf2ea1f02c#file-soul-shard-crash-report-txt-L23) changed to various other vanilla block types in different crashes.
